### PR TITLE
Return null if 'val' is falsy

### DIFF
--- a/src/filters/volume.js
+++ b/src/filters/volume.js
@@ -11,10 +11,10 @@ var units = {
 };
 
 module.exports = function volumeFilter(val) {
-    if (typeof val === 'number') {
-        return val;
-    } else if (val === '') {
+    if (!val) {
         return null;
+    } else if (typeof val === 'number') {
+        return val;
     }
 
     var unit = val.match(/(ml|cl|dl|l|liter)/) || [];


### PR DESCRIPTION
Make sure `val` is a valid String before using match by returning null on falsy values.

When using productStream I got this error:
```
TypeError: Cannot read property 'match' of undefined
    at Object.volumeFilter [as filter] (/Users/emilmork/Documents/dev/github/beer-api/node_modules/vinmonopolet/src/filters/volume.js:20:19)
    at /Users/emilmork/Documents/dev/github/beer-api/node_modules/vinmonopolet/src/models/set-props.js:15:38
    at Array.forEach (native)
    at setProps (/Users/emilmork/Documents/dev/github/beer-api/node_modules/vinmonopolet/src/models/set-props.js:6:10)
    at new Product (/Users/emilmork/Documents/dev/github/beer-api/node_modules/vinmonopolet/src/models/product.js:8:5)
```