### PR TITLE
Adds getStore from rev.eng. search API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ module.exports = {
   searchProducts: require('./retrievers/searchProducts'),
   getProduct: require('./retrievers/getProduct'),
   getProductsById: require('./retrievers/getProductsById'),
+  getProductsByStore: require('./retrievers/getProductsByStore'),
   getProductByBarcode: require('./retrievers/getProductByBarcode'),
 
   // Stream interface

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ module.exports = {
   // Searchers
   getFacets: require('./retrievers/getFacets'),
   getProducts: require('./retrievers/getProducts'),
+  getStores: require('./retrievers/getStores'),
   searchProducts: require('./retrievers/searchProducts'),
   getProduct: require('./retrievers/getProduct'),
   getProductsById: require('./retrievers/getProductsById'),

--- a/src/retrievers/getProductsByStore.js
+++ b/src/retrievers/getProductsByStore.js
@@ -1,0 +1,18 @@
+const objectAssign = require('object-assign')
+const getProducts = require('./getProducts')
+
+function getProductsByStore(store, opts) {
+  const id = typeof store.name === 'undefined' ? store : store.name
+  const facet = `availableInStores:${id}`
+  const options = objectAssign({}, opts || {})
+
+  let facets = [facet]
+  if (options.facet || options.facets) {
+    facets = facets.concat(options.facet || options.facets)
+  }
+  delete options.facet
+  options.facets = facets
+
+  return getProducts(options)
+}
+module.exports = getProductsByStore

--- a/src/retrievers/getStores.js
+++ b/src/retrievers/getStores.js
@@ -12,9 +12,10 @@ function getStores(opts) {
     page: Math.max(0, options.page - 1)
   }
 
-  if (options.lat && options.lon) {
-    query.latitude = options.lat
-    query.longitude = options.lon
+  const {lat, lon} = options.nearLocation || {}
+  if (lat && lon) {
+    query.latitude = lat
+    query.longitude = lon
   }
 
   if (options.query) {

--- a/src/retrievers/getStores.js
+++ b/src/retrievers/getStores.js
@@ -1,0 +1,46 @@
+const objectAssign = require('object-assign')
+const Store = require('../models/Store')
+const Pagination = require('../models/Pagination')
+const request = require('../util/request')
+
+const defaults = {page: 1}
+
+function getStores(opts) {
+  const options = objectAssign({}, defaults, opts || {})
+  const query = {
+    q: '*',
+    page: Math.max(0, options.page - 1)
+  }
+
+  if (options.lat && options.lon) {
+    query.latitude = options.lat
+    query.longitude = options.lon
+  }
+
+  if (options.query) {
+    query.q = options.query
+  }
+
+  const req = request.get('/vmp/store-finder', {
+    baseUrl: 'https://www.vinmonopolet.no',
+    query
+  })
+
+  return req.then(res => ({
+    stores: (res.data || []).map(i => new Store(i)),
+    pagination: new Pagination(getPagination(query.page, res), options, getStores)
+  }))
+}
+
+function getPagination(currentPage, res) {
+  const pageSize = 10 // Hard coded in the API
+
+  return {
+    currentPage,
+    pageSize,
+    totalPages: Math.ceil(res.total / pageSize),
+    totalResults: res.total
+  }
+}
+
+module.exports = getStores

--- a/test/vinmonopolet.test.js
+++ b/test/vinmonopolet.test.js
@@ -238,8 +238,10 @@ describe('vinmonopolet', function () {
 
     it('can get by location', () =>
       vinmonopolet.getStores({
-        lat: 63.405,
-        lon: 10.402
+        nearLocation: {
+          lat: 63.405,
+          lon: 10.402
+        }
       })
       .then(i => i.stores)
       .then(res => {

--- a/test/vinmonopolet.test.js
+++ b/test/vinmonopolet.test.js
@@ -230,6 +230,48 @@ describe('vinmonopolet', function () {
     )
   })
 
+  describe('getStores', () => {
+    it('can get first 10 stores', () =>
+      expect(vinmonopolet.getStores().then(i => i.stores))
+        .to.eventually.have.length(10)
+    )
+
+    it('can get by location', () =>
+      vinmonopolet.getStores({
+        lat: 63.405,
+        lon: 10.402
+      })
+      .then(i => i.stores)
+      .then(res => {
+        expect(res[0].displayName).to.be.equal('Trondheim, Byåsen')
+      })
+    )
+
+    it('can get by query', () =>
+      vinmonopolet.getStores({
+        query: 'Trondheim, Bankkvartalet'
+      })
+      .then(i => i.stores)
+      .then(res => {
+        expect(res[0].displayName).to.be.equal('Trondheim, Bankkvartalet')
+        expect(res[0].name).to.be.equal('160')
+      })
+    )
+
+    it('returns pagination info', () =>
+      vinmonopolet.getStores({ }).then(res => {
+        expect(res.stores).to.be.an('array').and.have.lengthOf(10)
+        expect(res.pagination).to.be.an.instanceOf(vinmonopolet.Pagination)
+        expect(res.pagination).to.have.property('currentPage', 0)
+        expect(res.pagination).to.have.property('pageSize', 10)
+        expect(res.pagination).to.have.property('hasNext', true)
+        expect(res.pagination).to.have.property('hasPrevious', false)
+        expect(res.pagination.totalPages).to.be.a('number').and.be.above(10)
+        expect(res.pagination.totalResults).to.be.a('number').and.be.above(100)
+      })
+    )
+  })
+
   describe('getFacets', () => {
     it('can get facets list, returns promise of array', () =>
       expect(vinmonopolet.getFacets())

--- a/test/vinmonopolet.test.js
+++ b/test/vinmonopolet.test.js
@@ -379,6 +379,22 @@ describe('vinmonopolet', function () {
     )
   })
 
+  describe('getProductsByStore', () => {
+    it('fetches products by store id', () =>
+      expect(vinmonopolet.getProductsByStore('160', {limit: 3}).then(i => i.products))
+        .to.eventually.have.length(3)
+    )
+
+    it('fetches products by store and with facet', () =>
+      vinmonopolet.getProductsByStore('160', {facet: vinmonopolet.Facet.Category.BEER})
+        .then(i => i.products)
+        .then(res => {
+          expect(res[0].chosenStoreStock.pointOfService).to.be.equal('160')
+          res.forEach(prod => expect(prod.productType).to.equal('Øl'))
+        })
+    )
+  })
+
   describe('getProductByBarcode', () => {
     it('fetches products by barcode', () =>
       vinmonopolet.getProducts({limit: 5, facets: [vinmonopolet.Facet.Category.BEER, 'mainCountry:norge']})


### PR DESCRIPTION
Through the stores CSV file from the Vinmonopolet "datadeling"-page, you don't get the store ID, and you cannot resolve from location for instance. This adds a retriever for getting stores by query and/or location.

This way we can add a facet for getting products by store (pull request to come).

Let me know what you think.