### PR TITLE
Update getFacets endpoint to new location

### DIFF
--- a/src/retrievers/getFacets.js
+++ b/src/retrievers/getFacets.js
@@ -2,14 +2,13 @@ const request = require('../util/request')
 const Facet = require('../models/Facet')
 
 function getFacets(opts) {
-  return request.get('/vmp/search/facets', {
+  return request.get('/api/search', {
     baseUrl: 'https://www.vinmonopolet.no',
     query: {
-      // 500 thrown if no "q" parameter supplied.
-      q: ''
+      fields: 'FULL'
     }
   })
-    .then(res => res.facets.map(i => new Facet(i)))
+    .then(res => res.productSearchResult.facets.map(i => new Facet(i)))
 }
 
 module.exports = getFacets


### PR DESCRIPTION
The old `/vmp/search/facets` endpoint appears to have been removed about a week ago. Facets are now returned inside the `/api/search` endpoint.

There's a bunch of tests failing so I imagine this isn't the only change they've made, I'll take a look and see if I can rectify some of those soon. Just selfishly PRing this one first since it's breaking stuff for me 😅